### PR TITLE
Improve activity selection UI, fix background path, and configure lint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "script"
+  },
+  "ignorePatterns": [
+    "node_modules/",
+    "api/LocalFunctions/"
+  ],
+  "rules": {}
+}

--- a/api/activity.js
+++ b/api/activity.js
@@ -35,7 +35,7 @@ function validateAndSanitizeInput(location) {
     }
     
     // Remove potentially harmful characters but keep international characters
-    const cleaned = sanitized.replace(/[<>\"'&]/g, '');
+    const cleaned = sanitized.replace(/[<>"'&]/g, '');
     return cleaned;
 }
 

--- a/api/spot.js
+++ b/api/spot.js
@@ -39,8 +39,8 @@ function validateInputs(location, activityString) {
     }
     
     return {
-        location: location.trim().replace(/[<>\"'&]/g, ''),
-        activityString: activityString.trim().replace(/[<>\"'&]/g, '')
+        location: location.trim().replace(/[<>"'&]/g, ''),
+        activityString: activityString.trim().replace(/[<>"'&]/g, '')
     };
 }
 
@@ -258,7 +258,7 @@ router.get('/cache-stats', (req, res) => {
     let validEntries = 0;
     let expiredEntries = 0;
     
-    for (const [key, value] of cache.entries()) {
+    for (const value of cache.values()) {
         if (now - value.timestamp < CACHE_DURATION) {
             validEntries++;
         } else {

--- a/public/script.js
+++ b/public/script.js
@@ -43,7 +43,6 @@ function initializeEventListeners() {
     };
 
     // Input handlers with debouncing
-    let locationTimeout;
     domElements.locationInput.addEventListener('input', debounce((e) => {
         const newLocation = e.target.value;
         if (newLocation && newLocation !== userLocation && newLocation.length > 2) {
@@ -191,7 +190,6 @@ async function fetchActivityFun() {
     // Check cache first
     const cachedData = getCachedData(cacheKey);
     if (cachedData) {
-        console.log('Using cached activities for:', formattedLocation);
         displayGeneralActivityButtons(cachedData);
         return;
     }
@@ -205,7 +203,6 @@ async function fetchActivityFun() {
     const timeoutId = setTimeout(() => loadingController.abort(), 25000); // 25s timeout
 
     try {
-        console.log('Fetching activities for:', formattedLocation);
         
         const response = await fetch(`/api/activity?location=${encodeURIComponent(formattedLocation)}`, {
             signal: loadingController.signal,
@@ -222,7 +219,6 @@ async function fetchActivityFun() {
         }
 
         const data = await response.json();
-        console.log('Received activities:', data);
 
         // Cache the successful response
         setCachedData(cacheKey, data);
@@ -246,21 +242,22 @@ async function fetchActivityFun() {
 
 // Optimized spot fetching
 async function fetchSpotFun() {
-    const activityInput = domElements.activityInput.value;
-    const combinedText = activityInput + (selectedActivities.size ? ' ; ' + Array.from(selectedActivities).join(' ; ') : '');
-    
-    if (!combinedText.trim()) {
+    const activityInput = domElements.activityInput.value.trim();
+    const parts = [];
+    if (activityInput) parts.push(activityInput);
+    if (selectedActivities.size) parts.push(...selectedActivities);
+    const combinedText = parts.join(' ; ');
+
+    if (!combinedText) {
         showError('Please select some activities or enter a custom search.');
         return;
     }
 
-    console.log('Fetching spots for:', userLocation, combinedText);
 
     const cacheKey = generateCacheKey(userLocation, combinedText);
     const cachedData = getCachedData(cacheKey);
     
     if (cachedData) {
-        console.log('Using cached spots');
         displaySpots(cachedData);
         return;
     }
@@ -290,7 +287,6 @@ async function fetchSpotFun() {
         }
 
         const data = await response.json();
-        console.log('Received spots:', data);
 
         setCachedData(cacheKey, data);
         displaySpots(data);
@@ -327,7 +323,7 @@ function displayGeneralActivityButtons(jsonObject) {
         button.innerText = activity;
         button.onclick = () => {
             displaySpecificActivityButtons(jsonObject[activity]);
-            toggleActivity(activity);
+            toggleActivity(activity, button);
         };
         
         // Add staggered animation delay
@@ -351,7 +347,7 @@ function displaySpecificActivityButtons(activities) {
         const button = document.createElement('button');
         button.classList.add('specific-activity-button');
         button.innerText = activity;
-        button.onclick = () => toggleActivity(activity);
+        button.onclick = () => toggleActivity(activity, button);
         fragment.appendChild(button);
     });
     
@@ -361,10 +357,9 @@ function displaySpecificActivityButtons(activities) {
 }
 
 // Optimized activity toggle
-function toggleActivity(activity) {
-    const button = Array.from(document.querySelectorAll('button')).find(btn => btn.innerText === activity);
+function toggleActivity(activity, button) {
     if (!button) return;
-    
+
     if (selectedActivities.has(activity)) {
         selectedActivities.delete(activity);
         button.classList.remove('active');
@@ -372,16 +367,14 @@ function toggleActivity(activity) {
         selectedActivities.add(activity);
         button.classList.add('active');
     }
-    
+
     updateActivityInput();
 }
 
 // Update activity input display
 function updateActivityInput() {
-    const activityText = domElements.activityInput.value;
     const selectedActivitiesText = Array.from(selectedActivities).join(' ; ');
-    const combinedText = activityText + (selectedActivitiesText ? ' ; ' + selectedActivitiesText : '');
-    console.log('Combined Text:', combinedText);
+    domElements.activityInput.placeholder = selectedActivitiesText || 'Custom Search (optional)';
 }
 
 // Optimized spots display
@@ -451,3 +444,5 @@ window.addEventListener('beforeunload', () => {
         loadingController.abort();
     }
 });
+window.fetchSpotFun = fetchSpotFun;
+

--- a/public/styles.css
+++ b/public/styles.css
@@ -3,7 +3,7 @@ html, body {
     margin: 0;
     padding: 0;
     font-family: Arial, sans-serif;
-    background: url('public/CosmosBackground.png'); /* Use only the background image */
+    background: url('CosmosBackground.png'); /* Use only the background image */
     background-size: cover; /* Ensure the image covers the viewport */
     background-repeat: no-repeat; /* Prevent repetition */
     background-attachment: fixed; /* Keep the background fixed during scrolling */
@@ -187,7 +187,7 @@ button:hover {
 
 body {
     font-family: Arial, sans-serif;
-    background: url('public/CosmosBackground.png');
+    background: url('CosmosBackground.png');
     background-size: cover;
     background-repeat: no-repeat;
     background-attachment: fixed;

--- a/server.js
+++ b/server.js
@@ -94,7 +94,7 @@ app.use('*', (req, res) => {
 });
 
 // Global error handler
-app.use((error, req, res, next) => {
+app.use((error, req, res) => {
     console.error('Global error handler:', error);
     res.status(500).json({ 
         error: 'Internal server error',


### PR DESCRIPTION
## Summary
- Build spot search queries without leading separators and handle empty inputs
- Toggle activities directly via button references and show selections in the custom search placeholder
- Correct background image path for consistent loading
- Add ESLint configuration and tidy scripts by removing debug logs and exposing spot search handler globally

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68921eb1711483319ce35116f270c6b7